### PR TITLE
changed serviceAccounts to make it work with latest OpenShift and Pipelines Operator

### DIFF
--- a/build-pipeline-run.yaml
+++ b/build-pipeline-run.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   pipelineRef:
     name: reverse-words-build-pipeline
-  serviceAccounts:
+  serviceAccountNames:
     - taskName: build-and-push
-      serviceAccount: reversewords-pipeline
+      serviceAccountName: reversewords-pipeline
   params:
     - name: imageTag
       value: "testing"

--- a/webhook.yaml
+++ b/webhook.yaml
@@ -28,9 +28,9 @@ spec:
       spec:
         pipelineRef:
           name: reverse-words-build-pipeline
-        serviceAccounts:
+        serviceAccountNames:
           - taskName: build-and-push
-            serviceAccount: reversewords-pipeline
+            serviceAccountName: reversewords-pipeline
         params:
           - name: imageTag
             value: $(params.gitrevision)


### PR DESCRIPTION
https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md

there seems to be a change. I tested the old style and it failed because it cannot validate serviceAccounts

tested on 4.4. with PipelinesOperator